### PR TITLE
🛳️ Add simple Guild Ship management

### DIFF
--- a/actions/guild-ship.ts
+++ b/actions/guild-ship.ts
@@ -1,0 +1,48 @@
+import { GuildShipInfo } from '../models/guild-ship.ts'
+import { ActionType } from './index.ts'
+
+export interface CreatedGuildShipAction {
+  type: ActionType.CreatedGuildShip
+  ship: GuildShipInfo
+}
+
+export function createdGuildShip(ship: GuildShipInfo): CreatedGuildShipAction {
+  return {
+    type: ActionType.CreatedGuildShip,
+    ship,
+  }
+}
+
+export interface RemovedGuildShipAction {
+  type: ActionType.RemovedGuildShip
+  guildId: string
+  rareId: string
+}
+
+export function removedGuildShip(
+  guildId: string,
+  rareId: string,
+): RemovedGuildShipAction {
+  return {
+    type: ActionType.RemovedGuildShip,
+    guildId,
+    rareId,
+  }
+}
+
+export interface UpdatedGuildShipAction {
+  type: ActionType.UpdatedGuildShip
+  ship: GuildShipInfo
+}
+
+export function updatedGuildShip(ship: GuildShipInfo): UpdatedGuildShipAction {
+  return {
+    type: ActionType.UpdatedGuildShip,
+    ship,
+  }
+}
+
+export type GuildShipAction =
+  | CreatedGuildShipAction
+  | RemovedGuildShipAction
+  | UpdatedGuildShipAction

--- a/actions/index.ts
+++ b/actions/index.ts
@@ -1,4 +1,10 @@
 import { checkFleet, closedFleet, FleetAction, newFleet } from './fleet.ts'
+import {
+  createdGuildShip,
+  GuildShipAction,
+  removedGuildShip,
+  updatedGuildShip,
+} from './guild-ship.ts'
 import { checkAll, checkGuild, GuildAction } from './guild.ts'
 import {
   activePlayer,
@@ -29,14 +35,17 @@ export enum ActionType {
   CheckFleet = 'FLEET_CHECK',
   CheckShip = 'SHIP_CHECK',
   ClosedFleet = 'FLEET_CLOSED',
+  CreatedGuildShip = 'GUILD_SHIP_CREATED',
   DeactivePlayer = 'PLAYER_DEACTIVE',
   DroppedShip = 'SHIP_DROPPED',
   JoinedShip = 'SHIP_JOINED',
   LeftShip = 'SHIP_LEFT',
   NewFleet = 'FLEET_NEW',
   Other = '__OTHER_ACTIONS__', // For default typing in case statements
+  RemovedGuildShip = 'GUILD_SHIP_REMOVED',
   UnalarmShipBaby = 'SHIP_BABY_REMOVE_ALARM',
   UnalarmShipLow = 'SHIP_LOW_REMOVE_ALARM',
+  UpdatedGuildShip = 'GUILD_SHIP_UPDATED',
 }
 
 export interface OtherAction {
@@ -46,6 +55,7 @@ export interface OtherAction {
 export type Action =
   | FleetAction
   | GuildAction
+  | GuildShipAction
   | PlayerAction
   | ShipAction
   | OtherAction
@@ -60,9 +70,12 @@ export {
   checkGuild,
   checkShip,
   closedFleet,
+  createdGuildShip,
   deactivePlayer,
   droppedShip,
   joinedShip,
   leftShip,
   newFleet,
+  removedGuildShip,
+  updatedGuildShip,
 }

--- a/epics/checks/guild-ships.ts
+++ b/epics/checks/guild-ships.ts
@@ -1,0 +1,176 @@
+import { ofType, StateObservable } from 'redux-observable'
+import { DiscordDependency } from '../model.ts'
+import { Store } from '../../models/store/index.ts'
+import {
+  filter,
+  from,
+  merge,
+  mergeMap,
+  Observable,
+  shareReplay,
+  switchMap,
+  withLatestFrom,
+} from 'rxjs'
+import { Action, ActionType } from '../../actions/index.ts'
+import { CategoryChannel, ChannelType } from 'discord.js'
+import nlp from 'compromise'
+import {
+  getGuildShipChannelName,
+  getGuildShipInfo,
+  GuildShipInfo,
+  RareGuildShip,
+  RareGuildShipsResponse,
+} from '../../models/guild-ship.ts'
+import {
+  createdGuildShip,
+  removedGuildShip,
+  updatedGuildShip,
+} from '../../actions/guild-ship.ts'
+
+const DataPath = '_data'
+const GuildShipsFilename = 'guild-ships.json'
+
+interface NoGuildShips {
+  type: 'none'
+}
+
+interface ExistingShip {
+  ship: GuildShipInfo
+  rareShip: RareGuildShip
+}
+
+interface CheckGuildShips {
+  type: 'check'
+  guildId: string
+  fleetId: string
+  newShips: RareGuildShip[]
+  existingShips: ExistingShip[]
+  removedShips: GuildShipInfo[]
+}
+
+function isCheck(
+  item: NoGuildShips | CheckGuildShips,
+): item is CheckGuildShips {
+  return item.type === 'check'
+}
+
+export function checkGuildShipsEpic(
+  action: Observable<Action>,
+  state: StateObservable<Store>,
+  { client }: DiscordDependency,
+) {
+  const checkGuildShips = action.pipe(
+    ofType(ActionType.CheckGuild),
+    withLatestFrom(state),
+    switchMap(
+      async ([action, state]): Promise<NoGuildShips | CheckGuildShips> => {
+        const guildId = action.guildId
+        const fleet = client.guilds.resolve(guildId)?.channels.valueOf().find(
+          (c) =>
+            c instanceof CategoryChannel &&
+            nlp(c.name).match('guild ships'),
+        )
+        if (!fleet) {
+          return { type: 'none' }
+        }
+        let rareShips: RareGuildShipsResponse | null = null
+        try {
+          const rareShipsFile = await Deno.readTextFile(
+            `${DataPath}/${guildId}/${GuildShipsFilename}`,
+          )
+          rareShips = JSON.parse(rareShipsFile)
+        } catch (error) {
+          console.warn(
+            `Error reading rare ships file for [Discord] guild ${guildId}:`,
+            error,
+          )
+          return { type: 'none' }
+        }
+        const ships = state.guilds[guildId]?.guildShips || {}
+        const encountered = new Set<string>()
+        const newShips: RareGuildShip[] = []
+        const existingShips: ExistingShip[] = []
+        for (const ship of rareShips?.Ships ?? []) {
+          encountered.add(ship.Id)
+          if (!ships[ship.Id]) {
+            newShips.push(ship)
+          } else {
+            existingShips.push({ ship: ships[ship.Id].info, rareShip: ship })
+          }
+        }
+        const removedShips = Object.keys(ships).filter((id) =>
+          !encountered.has(id)
+        ).map((id) => ships[id].info)
+        return {
+          type: 'check',
+          guildId,
+          fleetId: fleet.id,
+          newShips,
+          existingShips,
+          removedShips,
+        }
+      },
+    ),
+    shareReplay(1),
+  )
+
+  const createdShips = checkGuildShips.pipe(
+    filter(isCheck),
+    switchMap(({ guildId, fleetId, newShips }) =>
+      from(newShips!.map((rareShip) => ({ guildId, fleetId, rareShip })))
+    ),
+    mergeMap(async ({ guildId, fleetId, rareShip }) => {
+      const guild = client.guilds.resolve(guildId)!
+      const rareShipInfo = getGuildShipInfo(guildId, fleetId, '', rareShip)
+      const channel = await guild.channels.create({
+        name: getGuildShipChannelName(rareShipInfo),
+        type: ChannelType.GuildVoice,
+        parent: fleetId,
+      })
+      return createdGuildShip(
+        getGuildShipInfo(guildId, fleetId, channel.id, rareShip),
+      )
+    }),
+  )
+
+  const updatedShips = checkGuildShips.pipe(
+    filter(isCheck),
+    switchMap(({ guildId, fleetId, existingShips }) =>
+      from(
+        existingShips!.map(({ ship, rareShip }) => ({
+          guildId,
+          fleetId,
+          ship,
+          rareShip,
+        })),
+      )
+    ),
+    mergeMap(async ({ guildId, fleetId, ship, rareShip }) => {
+      const rareShipInfo = getGuildShipInfo(guildId, fleetId, ship.id, rareShip)
+      if (
+        ship.name !== rareShipInfo.name ||
+        ship.shipType !== rareShipInfo.shipType
+      ) {
+        const guild = client.guilds.resolve(guildId)!
+        const channel = guild.channels.resolve(ship.id)
+        await channel?.setName(getGuildShipChannelName(rareShipInfo))
+      }
+      return updatedGuildShip(rareShipInfo)
+    }),
+  )
+
+  const removedShips = checkGuildShips.pipe(
+    filter(isCheck),
+    switchMap(({ guildId, removedShips }) =>
+      from(removedShips!.map((ship) => ({ guildId, ship })))
+    ),
+    mergeMap(async ({ guildId, ship }) => {
+      const guild = client.guilds.resolve(guildId)!
+      const channel = guild.channels.resolve(ship.id)
+      await channel?.delete()
+      return removedGuildShip(guildId, ship.rareId)
+    }),
+  )
+
+  return merge(createdShips, updatedShips, removedShips)
+}

--- a/epics/index.ts
+++ b/epics/index.ts
@@ -4,8 +4,9 @@ import playerActivityAlarmEpic from './alarms/player-activity.ts'
 import shipCountAlarmsEpic from './alarms/ship-counts.ts'
 import basicLoggingEpic from './basic-logging.ts'
 import checkAllEpic from './checks/all.ts'
-import checkGuildEpic from './checks/guild.ts'
 import checkFleetEpic from './checks/fleet.ts'
+import { checkGuildShipsEpic } from './checks/guild-ships.ts'
+import checkGuildEpic from './checks/guild.ts'
 import checkShipEpic from './checks/ship.ts'
 import checkSometimesEpic from './checks/sometimes.ts'
 import reportFleetStatusEpic from './fleet-status.ts'
@@ -17,6 +18,7 @@ const rootEpic = combineEpics(
   checkAllEpic,
   checkFleetEpic,
   checkGuildEpic,
+  checkGuildShipsEpic,
   checkShipEpic,
   checkSometimesEpic,
   playerActivityEpic,

--- a/index.ts
+++ b/index.ts
@@ -62,7 +62,7 @@ const epicMiddleware = createEpicMiddleware<Action, Action, Store>({
 const store = createStore(reducer, baseState, applyMiddleware(epicMiddleware))
 
 await readyClient.user.setPresence({
-  activities: [{ name: 'ALL THE SHIPS', state: 'WATCHING' }],
+  activities: [{ name: 'ALL THE SHIPS', type: Discord.ActivityType.Watching }],
 })
 
 epicMiddleware.run(rootEpic)

--- a/models/guild-ship.ts
+++ b/models/guild-ship.ts
@@ -1,0 +1,90 @@
+import { ChannelType } from './channel-type.ts'
+import { nlp } from './index.ts'
+import { ShipInfo, shipTypes } from './ship.ts'
+
+export interface GuildShipInfo extends ShipInfo {
+  /**
+   * The ID of the Ship in Rare's systems.
+   *
+   * These seem to be GUIDs, but easiest to treat it as an opaque string.
+   */
+  rareId: string
+}
+
+/**
+ * Represents a Ship in Rare's systems.
+ */
+export interface RareGuildShip {
+  /**
+   * The ID of the Ship in Rare's systems.
+   */
+  Id: string
+
+  /**
+   * The name of the Ship.
+   */
+  Name: string
+
+  /**
+   * The type of the Ship.
+   */
+  Type: string
+
+  /**
+   * The sailing state of the Ship.
+   *
+   * This would be real nice if we could get real-time updates on the sailing state.
+   */
+  SailingState?: string
+
+  /**
+   * The sail image of the Ship.
+   *
+   * I wonder if we could display these in Discord somewhere.
+   */
+  SailImage?: string
+
+  /**
+   * The alignment of the Ship.
+   *
+   * Seems to be the Title of the ship, but not exactly. (Doesn't include "Legendary", for instance)
+   */
+  Alignment?: string
+}
+
+export interface RareGuildShipsResponse {
+  Ships: RareGuildShip[]
+}
+
+export function getGuildShipInfo(
+  guildId: string,
+  fleetId: string,
+  id: string,
+  ship: RareGuildShip,
+): GuildShipInfo {
+  const shipType = nlp(ship.Type).match('#Ship').out('normal')
+  return {
+    type: ChannelType.Ship,
+    id,
+    rareId: ship.Id,
+    name: ship.Name,
+    guildId,
+    fleetId,
+    shipType,
+    number: null,
+  }
+}
+
+export function getGuildShipChannelName(ship: GuildShipInfo): string {
+  const spots = shipTypes[ship.shipType]?.total
+  switch (spots) {
+    case 4:
+      return `${ship.name} 4️⃣`
+    case 3:
+      return `${ship.name} 3️⃣`
+    case 2:
+      return `${ship.name} 2️⃣`
+    default:
+      return ship.name
+  }
+}

--- a/models/store/guild-ship.ts
+++ b/models/store/guild-ship.ts
@@ -1,0 +1,21 @@
+import { GuildShipInfo } from '../guild-ship.ts'
+
+export interface GuildShip {
+  readonly info: GuildShipInfo
+  /*
+  Would it be as useful to track this for Guild ships?
+
+  readonly active: ShipPlayerStore
+  readonly leaving: ShipPlayerStore
+  readonly left: ShipPlayerStore
+  readonly visiting: ShipPlayerStore
+  readonly alarms?: {
+    readonly babies?: number
+    readonly low?: number
+  }
+  */
+}
+
+export interface GuildShipStore {
+  readonly [shipRareId: string]: GuildShip
+}

--- a/models/store/index.ts
+++ b/models/store/index.ts
@@ -1,8 +1,10 @@
 import { FleetStore } from './fleet.ts'
+import { GuildShipStore } from './guild-ship.ts'
 
 export interface GuildStore {
   readonly [guildId: string]: {
     readonly fleets: FleetStore
+    readonly guildShips?: GuildShipStore
   }
 }
 

--- a/reducers/guild-ships.ts
+++ b/reducers/guild-ships.ts
@@ -1,0 +1,26 @@
+import { Draft } from 'immer'
+import { Action, ActionType } from '../actions/index.ts'
+import { Store } from '../models/store/index.ts'
+import { getGuildShips } from './model.ts'
+
+export function guildShipsReducer(draft: Draft<Store>, action: Action) {
+  switch (action.type) {
+    case ActionType.CreatedGuildShip: {
+      const guildShips = getGuildShips(draft, action.ship.guildId)
+      guildShips[action.ship.rareId] = { info: action.ship }
+      break
+    }
+    case ActionType.RemovedGuildShip: {
+      const guildShips = getGuildShips(draft, action.guildId)
+      delete guildShips[action.rareId]
+      break
+    }
+    case ActionType.UpdatedGuildShip: {
+      const guildShips = getGuildShips(draft, action.ship.guildId)
+      if (guildShips[action.ship.rareId]) {
+        guildShips[action.ship.rareId].info = action.ship
+      }
+      break
+    }
+  }
+}

--- a/reducers/index.ts
+++ b/reducers/index.ts
@@ -4,9 +4,11 @@ import { initialState } from '../models/store/index.ts'
 import fleetReducer from './fleet.ts'
 import playerReducer from './player.ts'
 import shipReducer from './ship.ts'
+import { guildShipsReducer } from './guild-ships.ts'
 
 const reducer = produce((draft, action: Action) => {
   fleetReducer(draft, action)
+  guildShipsReducer(draft, action)
   shipReducer(draft, action)
   playerReducer(draft, action)
 }, initialState)

--- a/reducers/model.ts
+++ b/reducers/model.ts
@@ -2,13 +2,18 @@ import { Draft } from 'immer'
 import { Store } from '../models/store/index.ts'
 import { FleetInfo, PlayerInfo, ShipInfo } from '../models/index.ts'
 
-export function getFleet(draft: Draft<Store>, info: FleetInfo) {
-  let guild = draft.guilds[info.guildId]
+export function getGuild(draft: Draft<Store>, guildId: string) {
+  let guild = draft.guilds[guildId]
   if (!guild) {
-    guild = draft.guilds[info.guildId] = {
+    guild = draft.guilds[guildId] = {
       fleets: {},
     }
   }
+  return guild
+}
+
+export function getFleet(draft: Draft<Store>, info: FleetInfo) {
+  const guild = getGuild(draft, info.guildId)
   let fleet = guild.fleets[info.id]
   if (!fleet) {
     fleet = guild.fleets[info.id] = {
@@ -19,6 +24,14 @@ export function getFleet(draft: Draft<Store>, info: FleetInfo) {
     }
   }
   return fleet
+}
+
+export function getGuildShips(draft: Draft<Store>, guildId: string) {
+  const guild = getGuild(draft, guildId)
+  if (!guild.guildShips) {
+    guild.guildShips = {}
+  }
+  return guild.guildShips
 }
 
 export function getShip(

--- a/reports/actions.ts
+++ b/reports/actions.ts
@@ -40,6 +40,11 @@ export default function actionReport(action: Action) {
         action.fleet.guildId,
         `**Ship change:** ${action.fleet.name} ${action.oldShip.name} ➡ ${action.ship.name}`,
       ]
+    case ActionType.CreatedGuildShip:
+      return [
+        action.ship.guildId,
+        `Created guild ship: ${action.ship.name}`,
+      ]
     case ActionType.CheckGuild:
       return [action.guildId, '**Reviewing all fleets**']
     case ActionType.CheckFleet:
@@ -73,6 +78,11 @@ export default function actionReport(action: Action) {
       ]
     case ActionType.NewFleet:
       return [action.fleet.guildId, `**New fleet:** ${action.fleet.name}`]
+    case ActionType.RemovedGuildShip:
+      return [
+        action.guildId,
+        `Removed guild ship: ${action.rareId}`,
+      ]
     case ActionType.UnalarmShipBaby:
       return [
         action.fleet.guildId,
@@ -82,6 +92,11 @@ export default function actionReport(action: Action) {
       return [
         action.fleet.guildId,
         `${action.fleet.name} ${action.ship.name} has filled back up`,
+      ]
+    case ActionType.UpdatedGuildShip:
+      return [
+        action.ship.guildId,
+        `Updated guild ship: ${action.ship.name}`,
       ]
   }
   return [null, action.type]


### PR DESCRIPTION
Given a dump of the `guild-ships` API from the seaofthieves.com website to a file `_data/{discordGuildId}/guild-ships.json`, SHARON will add/update/remove voice channels based on those SoT Guild ships.

I wish I could also automate the API call instead of dumping it manually, but it uses Cookie Auth based on your Live ID/MS Account and also isn't documented for general use, so the easiest/most easily allowed approach for now seems to be manual dumps.