### PR TITLE
Fix guild ship channel name sync

### DIFF
--- a/epics/checks/guild-ships.ts
+++ b/epics/checks/guild-ships.ts
@@ -12,12 +12,7 @@ import {
   withLatestFrom,
 } from 'rxjs'
 import { Action, ActionType } from '../../actions/index.ts'
-import {
-  CategoryChannel,
-  ChannelType,
-  Collection,
-  GuildEmoji,
-} from 'discord.js'
+import { CategoryChannel, ChannelType } from 'discord.js'
 import nlp from 'compromise'
 import {
   getGuildShipChannelName,

--- a/epics/checks/guild-ships.ts
+++ b/epics/checks/guild-ships.ts
@@ -12,7 +12,7 @@ import {
   withLatestFrom,
 } from 'rxjs'
 import { Action, ActionType } from '../../actions/index.ts'
-import { CategoryChannel, ChannelType } from 'discord.js'
+import { CategoryChannel, ChannelType, Collection, GuildEmoji } from 'discord.js'
 import nlp from 'compromise'
 import {
   getGuildShipChannelName,
@@ -65,7 +65,8 @@ export function checkGuildShipsEpic(
     switchMap(
       async ([action, state]): Promise<NoGuildShips | CheckGuildShips> => {
         const guildId = action.guildId
-        const fleet = client.guilds.resolve(guildId)?.channels.valueOf().find(
+        const guild = client.guilds.resolve(guildId)
+        const fleet = guild?.channels.valueOf().find(
           (c) =>
             c instanceof CategoryChannel &&
             nlp(c.name).match('guild ships'),
@@ -147,9 +148,10 @@ export function checkGuildShipsEpic(
     ),
     mergeMap(async ({ guildId, fleetId, ship, rareShip }) => {
       const rareShipInfo = getGuildShipInfo(guildId, fleetId, ship.id, rareShip)
+      const currentShipName = client.guilds.resolve(guildId)!.channels.resolve(ship.id)?.name
+      const rareShipName = getGuildShipChannelName(rareShipInfo)
       if (
-        ship.name !== rareShipInfo.name ||
-        ship.shipType !== rareShipInfo.shipType
+        currentShipName !== rareShipName
       ) {
         const guild = client.guilds.resolve(guildId)!
         const channel = guild.channels.resolve(ship.id)

--- a/epics/checks/guild-ships.ts
+++ b/epics/checks/guild-ships.ts
@@ -12,7 +12,12 @@ import {
   withLatestFrom,
 } from 'rxjs'
 import { Action, ActionType } from '../../actions/index.ts'
-import { CategoryChannel, ChannelType, Collection, GuildEmoji } from 'discord.js'
+import {
+  CategoryChannel,
+  ChannelType,
+  Collection,
+  GuildEmoji,
+} from 'discord.js'
 import nlp from 'compromise'
 import {
   getGuildShipChannelName,
@@ -148,7 +153,9 @@ export function checkGuildShipsEpic(
     ),
     mergeMap(async ({ guildId, fleetId, ship, rareShip }) => {
       const rareShipInfo = getGuildShipInfo(guildId, fleetId, ship.id, rareShip)
-      const currentShipName = client.guilds.resolve(guildId)!.channels.resolve(ship.id)?.name
+      const currentShipName = client.guilds.resolve(guildId)!.channels.resolve(
+        ship.id,
+      )?.name
       const rareShipName = getGuildShipChannelName(rareShipInfo)
       if (
         currentShipName !== rareShipName

--- a/models/guild-ship.ts
+++ b/models/guild-ship.ts
@@ -1,4 +1,3 @@
-import * as Discord from 'discord.js'
 import { ChannelType } from './channel-type.ts'
 import { nlp } from './index.ts'
 import { ShipInfo, shipTypes } from './ship.ts'

--- a/models/guild-ship.ts
+++ b/models/guild-ship.ts
@@ -1,3 +1,4 @@
+import * as Discord from 'discord.js'
 import { ChannelType } from './channel-type.ts'
 import { nlp } from './index.ts'
 import { ShipInfo, shipTypes } from './ship.ts'
@@ -82,7 +83,7 @@ export function getGuildShipChannelName(ship: GuildShipInfo): string {
       return `${ship.name} 4️⃣`
     case 3:
       return `${ship.name} 3️⃣`
-    case 2:
+    case 2: 
       return `${ship.name} 2️⃣`
     default:
       return ship.name

--- a/models/guild-ship.ts
+++ b/models/guild-ship.ts
@@ -83,7 +83,7 @@ export function getGuildShipChannelName(ship: GuildShipInfo): string {
       return `${ship.name} 4️⃣`
     case 3:
       return `${ship.name} 3️⃣`
-    case 2: 
+    case 2:
       return `${ship.name} 2️⃣`
     default:
       return ship.name


### PR DESCRIPTION
I wanted to use Discord emoji for the ship types, but it doesn't look like Discord supports that in channel names, so back to the drawing board on that, but it's nice to have working guild ship channel renaming as a consequence of that failed attempt.